### PR TITLE
configure webpack to split vendor libraries in a separate chunk

### DIFF
--- a/extension/.flowconfig
+++ b/extension/.flowconfig
@@ -2,10 +2,10 @@
 .*/node_modules/.*
 
 [include]
+src/
 
 [libs]
 node_modules/flow-interfaces-chrome/interfaces/
-src/js/browser_types.js
 
 [lints]
 

--- a/extension/flow-typed/webextension-polyfill.js
+++ b/extension/flow-typed/webextension-polyfill.js
@@ -91,3 +91,11 @@ declare var browser: {
   tabs: browser$tabs,
   scripting: browser$scripting,
 }
+
+
+declare module "webextension-polyfill" {
+  declare var storage: browser$storage;
+  declare var permissions: browser$permissions;
+  declare var tabs: browser$tabs;
+  declare var scripting: browser$scripting;
+}

--- a/extension/src/js/background.js
+++ b/extension/src/js/background.js
@@ -1,5 +1,4 @@
 /* @flow */
-// TODO do I really need to annotate all files with @flow??
 
 
 // hmm this works if you declare type: module in manifest
@@ -7,16 +6,19 @@
 // I assume this is only processed with webpack
 // import * as browser from "./browser-polyfill"
 
-const manifestVersion = chrome.runtime.getManifest().manifest_version
-if (manifestVersion == 3) {
-    // for v3 it's provided via manifest
-    try {
-        /* eslint-disable no-undef */
-        importScripts('./browser-polyfill.js')
-    } catch (e) {
-        console.error(e)
-    }
-}
+// this works with v3 if you need to
+// const manifestVersion = chrome.runtime.getManifest().manifest_version
+// if (manifestVersion == 3) {
+//     // for v3 it's provided via manifest
+//     try {
+//         /* eslint-disable no-undef */
+//         importScripts('./browser-polyfill.js')
+//     } catch (e) {
+//         console.error(e)
+//     }
+// }
+
+import * as browser from "webextension-polyfill"
 
 
 import {COMMAND_CAPTURE_SIMPLE, METHOD_CAPTURE_WITH_EXTRAS, showNotification} from './common'

--- a/extension/src/js/options.js
+++ b/extension/src/js/options.js
@@ -1,4 +1,6 @@
 /* @flow */
+import browser from "webextension-polyfill"
+
 
 export type Options = {
     endpoint: string;

--- a/extension/src/js/permissions.js
+++ b/extension/src/js/permissions.js
@@ -1,4 +1,6 @@
 /* @flow */
+import browser from "webextension-polyfill"
+
 
 function urlForPermissionsCheck(url: string): string {
     var u = new URL(url);

--- a/extension/src/options.html
+++ b/extension/src/options.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <script type="text/javascript" src="browser-polyfill.js"/></script>
+  <script type="text/javascript" src="webextension-polyfill.js"></script>
   <script type="text/javascript" src="options_page.js"/></script>
   <style>
    input:invalid {

--- a/extension/src/popup.html
+++ b/extension/src/popup.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <script type="text/javascript" src="browser-polyfill.js"></script>
+  <script type="text/javascript" src="webextension-polyfill.js"></script>
   <script type="text/javascript" src="popup.js"></script>
 </head>
 <body>


### PR DESCRIPTION
also generally makes it somewhat cleaner import-wise