### PR TITLE
Fix UnicodeEncodeError by ensuring UTF-8 encoding for file writes

### DIFF
--- a/src/grasp_backend/__main__.py
+++ b/src/grasp_backend/__main__.py
@@ -31,7 +31,7 @@ def append_org(
     # https://stackoverflow.com/a/13232181
     if len(org.encode('utf8')) > 4096:
         logger.warning("writing out %s might be non-atomic", org)
-    with path.open('a') as fo:
+    with path.open('a', encoding='utf-8') as fo:  # Added 'encoding='utf-8''
         fo.write(org)
 
 


### PR DESCRIPTION
his pull request addresses an issue encountered when using the Grasp extension with non-English characters. Specifically, an error (UnicodeEncodeError) occurred when attempting to write characters that are not supported by the default encoding on Windows (cp1252).

Changes Made:
Updated the append_org function in the __main__.py file to explicitly use UTF-8 encoding when writing to the .org file.
Reason for Change:
Using UTF-8 encoding ensures that the application can handle a broader range of characters, including Greek letters and other non-ASCII characters. This enhancement improves the usability of the extension for users who work with scientific articles containing diverse character sets.

How to Test:
Capture a note with non-English characters (e.g., Greek letters like "α-actinin").
Verify that the note is written to the .org file without any errors.